### PR TITLE
fix: preserve web build in docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,6 @@ services:
       context: ./apps/web
     ports:
       - "3000:3000"
-    volumes:
-      - ./apps/web:/app
     env_file:
       - .env
     depends_on:


### PR DESCRIPTION
## Summary
- remove web volume from docker-compose to keep Next.js production build available at runtime

## Testing
- `docker compose config` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_689ccb9dc2d48322b757eb00c7a0f93a